### PR TITLE
fix bug

### DIFF
--- a/python/LocalizableStringsFileUtil.py
+++ b/python/LocalizableStringsFileUtil.py
@@ -22,7 +22,7 @@ class LocalizableStringsFileUtil:
                 Log.error("Key:" + keys[x] + "\'s value is None. Index:" + str(x + 1))
                 continue
 
-            key = keys[x]
+            key = keys[x].strip()
             value = values[x]
             content = "\"" + key + "\" " + "= " + "\"" + value + "\";\n"
             fo.write(content);


### PR DESCRIPTION
The key string should not contain whitespace at the beginning or the end.
The syntax of iOS  language file can not support it.