### PR TITLE
Fix this script does not work on Python 2.7

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -35,7 +35,7 @@ pip 19.0 from /Library/Python/2.7/site-packages/pip (python 2.7)
 如果没有安装 pip
 
 ```
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
 sudo python get-pip.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip 19.0 from /Library/Python/2.7/site-packages/pip (python 2.7)
 if pip is not installed
 
 ```
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
 sudo python get-pip.py
 ```
 


### PR DESCRIPTION
curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
sudo python get-pip.py

Fix error
> ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/2.7/get-pip.py instead.